### PR TITLE
Enable SSL

### DIFF
--- a/CalDAVSyncAdapter/res/layout/activity_authenticator.xml
+++ b/CalDAVSyncAdapter/res/layout/activity_authenticator.xml
@@ -71,6 +71,14 @@
 
                 <requestFocus />
             </EditText>
+            
+    		<CheckBox
+    		    android:id="@+id/trustall"
+    		    android:layout_width="wrap_content"
+    		    android:layout_height="wrap_content"
+    		    android:checked="true"
+    		    android:text="@string/trustall"
+    		    android:visibility="invisible" />
 
             <Button
                 android:id="@+id/sign_in_button"

--- a/CalDAVSyncAdapter/res/menu/activity_authenticator.xml
+++ b/CalDAVSyncAdapter/res/menu/activity_authenticator.xml
@@ -1,8 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
-
-    <item
-        android:id="@+id/menu_forgot_password"
-        android:showAsAction="never"
-        android:title="@string/menu_forgot_password"/>
-
-</menu>

--- a/CalDAVSyncAdapter/res/values/strings_activity_authenticator.xml
+++ b/CalDAVSyncAdapter/res/values/strings_activity_authenticator.xml
@@ -21,5 +21,6 @@
     <string name="error_unkown_error">Unknown error</string>
     <string name="success_calendar">Connection success (calendar)</string>
     <string name="success_collection">Connection success (multiple calendars)</string>
+    <string name="trustall">Check SSL Certificate</string>
 
 </resources>

--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/Constants.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/Constants.java
@@ -24,5 +24,6 @@ package org.gege.caldavsyncadapter;
 public class Constants {
 
 	public static final String USER_DATA_URL_KEY = "USER_DATA_URL_KEY";
-
+	
+	public static final String USER_DATA_TRUST_ALL_KEY = "USER_DATA_TRUSTALL_KEY";
 }

--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/authenticator/AuthenticatorActivity.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/authenticator/AuthenticatorActivity.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.util.Locale;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -44,12 +45,15 @@ import android.app.Activity;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.Editable;
 import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -84,6 +88,7 @@ public class AuthenticatorActivity extends Activity {
 	private View mLoginFormView;
 	private View mLoginStatusView;
 	private TextView mLoginStatusMessageView;
+	private CheckBox mTrustCheckBox;
 
 	private AccountManager mAccountManager;
 
@@ -124,6 +129,24 @@ public class AuthenticatorActivity extends Activity {
 
 		
 		mURLView = (EditText) findViewById(R.id.url);
+		// if the URL start with "https" show the option to disable SSL host verification
+		mURLView.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before, int count) {
+				String url = ((EditText) findViewById(R.id.url)).getText().toString();
+				int visible = url.toLowerCase(Locale.getDefault()).startsWith("https") ? View.VISIBLE : View.INVISIBLE;
+				((CheckBox) findViewById(R.id.trustall)).setVisibility(visible);
+			}
+			
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count,
+					int after) {				
+			}
+			
+			@Override
+			public void afterTextChanged(Editable s) {				
+			}
+		});
 		
 		mLoginFormView = findViewById(R.id.login_form);
 		mLoginStatusView = findViewById(R.id.login_status);
@@ -136,6 +159,8 @@ public class AuthenticatorActivity extends Activity {
 						attemptLogin();
 					}
 				});
+		
+		mTrustCheckBox = (CheckBox) findViewById(R.id.trustall);
 		
 		
 	}
@@ -164,7 +189,7 @@ public class AuthenticatorActivity extends Activity {
 		mUser = mUserView.getText().toString();
 		mPassword = mPasswordView.getText().toString();
 		mURL = mURLView.getText().toString();
-		mTrustAll = "false";
+		mTrustAll = (mTrustCheckBox.isChecked() ? "false" : "true");
 
 		boolean cancel = false;
 		View focusView = null;

--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/authenticator/AuthenticatorActivity.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/authenticator/AuthenticatorActivity.java
@@ -76,6 +76,7 @@ public class AuthenticatorActivity extends Activity {
 	// Values for email and password at the time of the login attempt.
 	private String mUser;
 	private String mPassword;
+	private String mTrustAll;
 
 	// UI references.
 	private EditText mUserView;
@@ -163,6 +164,7 @@ public class AuthenticatorActivity extends Activity {
 		mUser = mUserView.getText().toString();
 		mPassword = mPasswordView.getText().toString();
 		mURL = mURLView.getText().toString();
+		mTrustAll = "false";
 
 		boolean cancel = false;
 		View focusView = null;
@@ -264,7 +266,7 @@ public class AuthenticatorActivity extends Activity {
 			TestConnectionResult result = null;
 			
 			try {
-				CaldavFacade facade = new CaldavFacade(mUser, mPassword, mURL);
+				CaldavFacade facade = new CaldavFacade(mUser, mPassword, mURL, mTrustAll);
 				result = facade.testConnection();
 				Log.i(TAG, "testConnection status="+result);
 			} catch (HttpHostConnectException e) {
@@ -303,6 +305,7 @@ public class AuthenticatorActivity extends Activity {
 				final Account account = new Account(mUser, "org.gege.caldavsyncadapter.account");			
 				mAccountManager.addAccountExplicitly(account, mPassword, null);
 				mAccountManager.setUserData(account, Constants.USER_DATA_URL_KEY, mURL);
+				mAccountManager.setUserData(account, Constants.USER_DATA_TRUST_ALL_KEY, mTrustAll);
 			
 				return LoginResult.Success_Calendar;
 

--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/authenticator/AuthenticatorActivity.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/authenticator/AuthenticatorActivity.java
@@ -142,7 +142,6 @@ public class AuthenticatorActivity extends Activity {
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
 		super.onCreateOptionsMenu(menu);
-		getMenuInflater().inflate(R.menu.activity_authenticator, menu);
 		return true;
 	}
 

--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/caldav/CaldavFacade.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/caldav/CaldavFacade.java
@@ -127,8 +127,10 @@ public class CaldavFacade {
 		return client;
 	}
 
-	public CaldavFacade(String mUser, String mPassword, String mURL) throws MalformedURLException {
+	public CaldavFacade(String mUser, String mPassword, String mURL, String mTrustAll) throws MalformedURLException {
 		url = new URL(mURL);
+		
+		trustAll = mTrustAll.equals("true");
 
 		httpClient = getHttpClient();
 

--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/syncadapter/SyncAdapter.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/syncadapter/SyncAdapter.java
@@ -115,13 +115,14 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
 			ContentProviderClient provider, SyncResult syncResult) {
 		
 		String url = mAccountManager.getUserData(account, Constants.USER_DATA_URL_KEY);
+		String trust = mAccountManager.getUserData(account, Constants.USER_DATA_TRUST_ALL_KEY);
 		Log.v(TAG, "onPerformSync() on "+account.name+" with URL "+url);
 
 		Iterable<Calendar> calendarList;
 		
 		try {
 			
-			CaldavFacade facade = new CaldavFacade(account.name, mAccountManager.getPassword(account), url);
+			CaldavFacade facade = new CaldavFacade(account.name, mAccountManager.getPassword(account), url, trust);
 			calendarList = facade.getCalendarList(getContext());
 			//String davProperties = facade.getLastDav();
 			


### PR DESCRIPTION
When using https connections the app used the "trust all" method for host certificate verification. While this is good for testing environments this should be optional.

I've created a new flag in the account's user data which specifies whether the "trust all" method should be used or the installed device root certificates are used. The option can be set during account creation and only shows up when the URL starts with https.
