### PR TITLE
sometimes provider.insert() returns null Uri, add null guard (refs #71)

### DIFF
--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/syncadapter/SyncAdapter.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/syncadapter/SyncAdapter.java
@@ -714,7 +714,10 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
 			Uri uri = provider.insert(asSyncAdapter(Events.CONTENT_URI, account.name, account.type), calendarEvent.ContentValues);
 			calendarEvent.setAndroidEventUri(uri);
 		
-			Log.d(TAG, "Creating calendar event for " + uri.toString());
+			if(uri == null)
+				Log.e(TAG, "Cannot create calendar event for null Uri!");
+			else
+				Log.d(TAG, "Creating calendar event for " + uri.toString());
 			
 			//check the attendees
 			java.util.ArrayList<ContentValues> AttendeeList = calendarEvent.getAttandees();


### PR DESCRIPTION
This will report the error and allow the sync to continue on, but the event
that caused the null Uri will be skipped and not synced.

This can be pulled directly in by doing:

```
git pull  https://github.com/eighthave/AndroidCaldavSyncAdapater null-uri-fix
```
