### PR TITLE
simple fix for issue #129: ignore <status> tag outside of <propstat>

### DIFF
--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/caldav/entities/CalendarEvent.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/caldav/entities/CalendarEvent.java
@@ -160,7 +160,7 @@ public class CalendarEvent extends org.gege.caldavsyncadapter.Event {
 					//HINT: bugfix for google calendar
 					if (response.href.equals(this.getUri().getPath().replace("@", "%40"))) {
 						propstat = response.propstat;
-						if (propstat.status.contains("200 OK")) {
+						if (propstat != null && propstat.status.contains("200 OK")) {
 							prop = propstat.prop;
 							ics = prop.calendardata;
 							this.setETag(prop.getetag);

--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/caldav/xml/MultiStatusHandler.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/caldav/xml/MultiStatusHandler.java
@@ -52,7 +52,7 @@ public class MultiStatusHandler extends DefaultHandler {
 	public void endElement(String uri, String localName, String qName) throws SAXException {
 		if (localName.equals(HREF)) {
 			mResponse.href = mCurrentValue;
-		} else if (localName.equals(STATUS)) {
+		} else if (localName.equals(STATUS) && mPropStat != null) {
 			mPropStat.status = mCurrentValue;
 		} else if (localName.equals(CALENDARDATA)) {
 			mProp.calendardata = mCurrentValue;


### PR DESCRIPTION
This patch fixes the NPE but is a bit dirty (because the MultiStatus class is now allowed to contain responses without propstat object; and because the XML parser just ignores the `<status>` tag instead of really handling it).
