### PR TITLE
Add checkbox to toggle visibility of password field, change field input ...

### DIFF
--- a/CalDAVSyncAdapter/res/layout/activity_authenticator.xml
+++ b/CalDAVSyncAdapter/res/layout/activity_authenticator.xml
@@ -45,9 +45,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/prompt_user"
-                android:inputType="text"
                 android:maxLines="1"
-                android:singleLine="true" />
+                android:singleLine="true"
+                android:inputType="text|textEmailAddress"
+                />
 
             <EditText
                 android:id="@+id/password"
@@ -60,6 +61,14 @@
                 android:inputType="textPassword"
                 android:maxLines="1"
                 android:singleLine="true" />
+
+
+            <CheckBox
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Display Password"
+                android:id="@+id/showPassword"
+                android:checked="false" />
 
             <EditText
                 android:id="@+id/url"

--- a/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/authenticator/AuthenticatorActivity.java
+++ b/CalDAVSyncAdapter/src/org/gege/caldavsyncadapter/authenticator/AuthenticatorActivity.java
@@ -45,12 +45,15 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -101,7 +104,9 @@ public class AuthenticatorActivity extends Activity {
 	
 	private String mAccountname;
 	private EditText mAccountnameView;
-	
+
+	private CheckBox showPassword;
+
 	public AuthenticatorActivity() {
 		super();
 		
@@ -119,6 +124,7 @@ public class AuthenticatorActivity extends Activity {
 		mUser = getIntent().getStringExtra(EXTRA_EMAIL);
 		mUserView = (EditText) findViewById(R.id.user);
 		mUserView.setText(mUser);
+		mUserView.requestFocus();
 		
 		mContext = getBaseContext();
 
@@ -135,6 +141,18 @@ public class AuthenticatorActivity extends Activity {
 						return false;
 					}
 				});
+
+		showPassword = (CheckBox) findViewById(R.id.showPassword);
+		showPassword.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+			@Override
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				if(isChecked) {
+					mPasswordView.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+				} else {
+					mPasswordView.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+				}
+			}
+		});
 
 		
 		mURLView = (EditText) findViewById(R.id.url);


### PR DESCRIPTION
...types, focus first field on activity startup

We are evaluating several Caldav providers and I had the issue that my keyboard (Swiftkey) tried to autocorrect the input of the userfield, so I quickly changed the type of that field to prevent this from happening. Also added a Show Password checkbox, which is very useful for people with super long passwords.
